### PR TITLE
Python 3.5 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ and `Run anyway`. I don't have certificate for signing and application does not 
 reputation so Microsoft will block by default.
 
 ### Source code
-1. Python 3.6 or newer is required
+1. Python 3.5 or newer is required
 2. Download from github or `git clone https://github.com/kolinger/rd-usb.git`
 3. Install requirements `pip install -r requirements.txt`
 4. Run with `python web.py` - this will spawn web server on http://127.0.0.1:5000, port can be changed 

--- a/web.py
+++ b/web.py
@@ -1,7 +1,13 @@
 import logging
 from logging import StreamHandler
 from logging.handlers import TimedRotatingFileHandler
-import secrets
+try:
+    from secrets import token_hex
+except ImportError:
+    from os import urandom
+
+    def token_hex(nbytes=None):
+        return urandom(nbytes).hex()
 import sys
 import threading
 import time
@@ -45,7 +51,7 @@ try:
     config = Config()
     secret_key = config.read("secret_key")
     if not secret_key:
-        secret_key = secrets.token_hex(16)
+        secret_key = token_hex(16)
         config.write("secret_key", secret_key)
     app.secret_key = secret_key
 


### PR DESCRIPTION
This PR adds Python 3.5 compatibility to rd-usb.

The main motivation is to make it work on Raspberry Pi. Python 3.5 is the newest version available out of the box on stock Raspbian.

So far only `token_hex` function from `secrets` module prevents rd-usb from running on Python 3.5.